### PR TITLE
fix(subscription): dispatch when only params changed

### DIFF
--- a/src/subscriptions.js
+++ b/src/subscriptions.js
@@ -41,8 +41,9 @@ let setupRouter = (dispatch, {reducer, props}) => {
 
                     const nextRoute = { ...route, params }
 
-                    // stop execution if route has not changed
-                    if (currentRoute.path === nextRoute.path) {
+                    // stop execution if route and params have not changed
+                    if (currentRoute.path === nextRoute.path &&
+                        currentRoute.keys.every(k => currentRoute.params[k] === nextRoute.params[k])) {
                         return
                     }
 


### PR DESCRIPTION
First of all, thank you very much for extending the already great Hyperway, it is
truly great to finally have a semi-workable example of routing in Hyperapp v2. ❤️ 

Currently `findRoute` only compares path when asserting when to dispatch events,
this means that transitions from routes as following would not trigger dispatches:

`/test/1 -> /test/2`

because paths might be defined the same as `/test/:id`.

This patch adds a simple comparison check for all the keys (params) in the current route the next
route if the path matches. Meaning changes in keys dispatches new events while exact same
keys do not.
